### PR TITLE
Add tenderbake support + fix seg fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ GIT_DESCRIBE ?= $(shell git describe --tags --abbrev=8 --always --long --dirty 2
 VERSION_TAG ?= $(shell echo "$(GIT_DESCRIBE)" | cut -f1 -d-)
 APPVERSION_M=2
 APPVERSION_N=2
-APPVERSION_P=13
-APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)
+APPVERSION_P=14
+APPVERSION=$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)-rc1
 
 # Only warn about version tags if specified/inferred
 ifeq ($(VERSION_TAG),)

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ python -m ledgerblue.loadApp \
     --tlv \
     --curve ed25519 \
     --curve secp256k1 \
-    --curve prime256r1 \
+    --curve secp256r1 \
     --targetId "${TARGET_ID:-0x31100004}" \
     --delete \
     --path 44"'"/1729"'" \

--- a/release-installer.sh
+++ b/release-installer.sh
@@ -32,7 +32,7 @@ for arg in "$@"; do
     --tlv \
     --curve ed25519 \
     --curve secp256k1 \
-    --curve prime256r1 \
+    --curve secp256r1 \
     --targetId "${target_id:?manifest file is missing field}" \
     --delete \
     --path "44'/1729'" \

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -27,9 +27,15 @@ static bool ok(void) {
         copy_bip32_path_with_curve(&ram->baking_key, &global.path_with_curve);
         ram->main_chain_id = G.main_chain_id;
         ram->hwm.main.highest_level = G.hwm.main;
+        ram->hwm.main.highest_round = 0;
         ram->hwm.main.had_endorsement = false;
+        ram->hwm.main.had_preendorsement = false;
+        ram->hwm.main.migrated_to_tenderbake = false;
         ram->hwm.test.highest_level = G.hwm.test;
+        ram->hwm.test.highest_round = 0;
         ram->hwm.test.had_endorsement = false;
+        ram->hwm.test.had_preendorsement = false;
+        ram->hwm.test.migrated_to_tenderbake = false;
     });
 
     cx_ecfp_public_key_t pubkey = {0};

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -471,13 +471,7 @@ static size_t handle_apdu(bool const enable_hashing,
                 parse_allowed_operations(&G.maybe_ops.v, buff, buff_size, &global.path_with_curve);
         } else {
             // This should be a baking operation so parse it.
-            if (buff[0] == 0) {
-                if (!parse_baking_data(&G.parsed_baking_data, buff + 1, buff_size - 1))
-                    PARSE_ERROR();
-            } else if (buff[0] == 1) {
-                if (!parse_tenderbake_baking_data(&G.parsed_baking_data, buff + 1, buff_size - 1))
-                    PARSE_ERROR();
-            }
+            if (!parse_baking_data(&G.parsed_baking_data, buff, buff_size)) PARSE_ERROR();
         }
 #else
         if (G.packet_index == 1) {

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -157,6 +157,9 @@ __attribute__((noreturn)) static void prompt_register_delegate(ui_callback_t con
 
 size_t baking_sign_complete(bool const send_hash) {
     switch (G.magic_byte) {
+        case MAGIC_BYTE_TENDERBAKE_BLOCK:
+        case MAGIC_BYTE_TENDERBAKE_PREENDORSEMENT:
+        case MAGIC_BYTE_TENDERBAKE_ENDORSEMENT:
         case MAGIC_BYTE_BLOCK:
         case MAGIC_BYTE_BAKING_OP:
             guard_baking_authorized(&G.parsed_baking_data, &global.path_with_curve);
@@ -411,6 +414,9 @@ static uint8_t get_magic_byte_or_throw(uint8_t const *const buff, size_t const b
     uint8_t const magic_byte = get_magic_byte(buff, buff_size);
     switch (magic_byte) {
 #ifdef BAKING_APP
+        case MAGIC_BYTE_TENDERBAKE_BLOCK:
+        case MAGIC_BYTE_TENDERBAKE_PREENDORSEMENT:
+        case MAGIC_BYTE_TENDERBAKE_ENDORSEMENT:
         case MAGIC_BYTE_BLOCK:
         case MAGIC_BYTE_BAKING_OP:
         case MAGIC_BYTE_UNSAFE_OP:  // Only for self-delegations

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -471,7 +471,13 @@ static size_t handle_apdu(bool const enable_hashing,
                 parse_allowed_operations(&G.maybe_ops.v, buff, buff_size, &global.path_with_curve);
         } else {
             // This should be a baking operation so parse it.
-            if (!parse_baking_data(&G.parsed_baking_data, buff, buff_size)) PARSE_ERROR();
+            if (buff[0] == 0) {
+                if (!parse_baking_data(&G.parsed_baking_data, buff + 1, buff_size - 1))
+                    PARSE_ERROR();
+            } else if (buff[0] == 1) {
+                if (!parse_tenderbake_baking_data(&G.parsed_baking_data, buff + 1, buff_size - 1))
+                    PARSE_ERROR();
+            }
         }
 #else
         if (G.packet_index == 1) {

--- a/src/baking_auth.c
+++ b/src/baking_auth.c
@@ -24,10 +24,15 @@ void write_high_water_mark(parsed_baking_data_t const *const in) {
     UPDATE_NVRAM(ram, {
         // If the chain matches the main chain *or* the main chain is not set, then use 'main' HWM.
         high_watermark_t volatile *const dest = select_hwm_by_chain(in->chain_id, ram);
+        if ((in->level > dest->highest_level) || (in->round > dest->highest_round)) {
+            dest->had_endorsement = false;
+            dest->had_preendorsement = false;
+        };
         dest->highest_level = CUSTOM_MAX(in->level, dest->highest_level);
-        dest->highest_round = CUSTOM_MAX(in->round, dest->highest_round);
-        dest->had_endorsement = in->type == BAKING_TYPE_ENDORSEMENT;
-        dest->had_preendorsement = in->type == BAKING_TYPE_PREENDORSEMENT;
+        dest->highest_round = in->round;
+        dest->had_endorsement |= in->type == BAKING_TYPE_ENDORSEMENT;
+        dest->had_preendorsement |= in->type == BAKING_TYPE_PREENDORSEMENT;
+        dest->migrated_to_tenderbake |= in->is_tenderbake;
     });
 }
 
@@ -51,7 +56,10 @@ static bool is_level_authorized(parsed_baking_data_t const *const baking_info) {
         select_hwm_by_chain(baking_info->chain_id, &N_data);
 
     if (baking_info->is_tenderbake) {
-        return baking_info->level > hwm->highest_level || baking_info->round > hwm->highest_round ||
+        return baking_info->level > hwm->highest_level ||
+
+               (baking_info->level == hwm->highest_level &&
+                baking_info->round > hwm->highest_round) ||
 
                // It is ok to sign an endorsement if we have not already signed an endorsement for
                // the level/round
@@ -60,13 +68,14 @@ static bool is_level_authorized(parsed_baking_data_t const *const baking_info) {
                 baking_info->type == BAKING_TYPE_ENDORSEMENT && !hwm->had_endorsement) ||
 
                // It is ok to sign a preendorsement if we have not already signed neither an
-               // endorsement or a preendorsement for the level/round
+               // endorsement nor a preendorsement for the level/round
                (baking_info->level == hwm->highest_level &&
                 baking_info->round == hwm->highest_round &&
                 baking_info->type == BAKING_TYPE_PREENDORSEMENT && !hwm->had_endorsement &&
                 !hwm->had_preendorsement);
 
     } else {
+        if (hwm->migrated_to_tenderbake) return false;
         return baking_info->level > hwm->highest_level
 
                // Levels are tied. In order for this to be OK, this must be an endorsement, and we
@@ -97,74 +106,20 @@ struct block_wire {
     uint32_t chain_id;
     uint32_t level;
     uint8_t proto;
+    uint8_t predecessor[32];
+    uint64_t timestamp;
+    uint8_t validation_pass;
+    uint8_t operation_hash[32];
+    uint32_t fitness_size;
     // ... beyond this we don't care
 } __attribute__((packed));
 
-struct endorsement_wire {
+struct consensus_op_wire {
     uint8_t magic_byte;
     uint32_t chain_id;
     uint8_t branch[32];
     uint8_t tag;
     uint32_t level;
-} __attribute__((packed));
-
-bool parse_baking_data(parsed_baking_data_t *const out,
-                       void const *const data,
-                       size_t const length) {
-    out->is_tenderbake = false;
-    out->round = 0;
-    switch (get_magic_byte(data, length)) {
-        case MAGIC_BYTE_BAKING_OP:
-            if (length != sizeof(struct endorsement_wire)) return false;
-            struct endorsement_wire const *const endorsement = data;
-            out->type = BAKING_TYPE_ENDORSEMENT;
-            out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &endorsement->chain_id);
-            out->level = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &endorsement->level);
-            return true;
-        case MAGIC_BYTE_BLOCK:
-            if (length < sizeof(struct block_wire)) return false;
-            struct block_wire const *const block = data;
-            out->type = BAKING_TYPE_BLOCK;
-            out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->chain_id);
-            out->level = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->level);
-            return true;
-        case MAGIC_BYTE_INVALID:
-        default:
-            return false;
-    }
-}
-
-struct tenderbake_locked_round_fitness_wire {
-    int32_t level;
-    uint8_t locked_round_tag;
-    int32_t locked_round;
-    int32_t predecessor_round;
-    int32_t round;
-} __attribute__((packed));
-
-struct tenderbake_no_locked_round_fitness_wire {
-    int32_t level;
-    uint8_t locked_round_tag;
-    int32_t predecessor_round;
-    int32_t round;
-} __attribute__((packed));
-
-struct tenderbake_block_wire {
-    uint8_t magic_byte;
-    uint32_t chain_id;
-    uint32_t level;
-    uint8_t proto;
-    uint8_t predecessor[32];
-    int64_t timestamp;
-    uint8_t validation_pass;
-    uint8_t operations_hash[32];
-    uint32_t fitness_size;
-    int32_t fitness_level;
-    uint8_t locked_round_tag;
-    union {
-        struct tenderbake_locked_round_fitness_wire locked_round;
-        struct tenderbake_no_locked_round_fitness_wire no_locked_round;
-    };
     // ... beyond this we don't care
 } __attribute__((packed));
 
@@ -179,40 +134,85 @@ struct tenderbake_consensus_op_wire {
     uint8_t block_payload_hash[32];
 } __attribute__((packed));
 
-bool parse_tenderbake_baking_data(parsed_baking_data_t *const out,
-                                  void const *const data,
-                                  size_t const length) {
-    out->is_tenderbake = true;
+#define EMMY_FITNESS_SIZE               17
+#define MINIMAL_TENDERBAKE_FITNESS_SIZE 33  // Locked round = None, otherwise 37
+
+#define TENDERBAKE_PROTO_FITNESS_VERSION 2
+
+uint8_t get_proto_version(void const *const fitness) {
+    return READ_UNALIGNED_BIG_ENDIAN(uint8_t, fitness + sizeof(uint32_t));
+}
+
+uint32_t get_round(void const *const fitness, uint32_t fitness_size) {
+    return READ_UNALIGNED_BIG_ENDIAN(uint32_t, (fitness + fitness_size - 4));
+}
+
+bool parse_block(parsed_baking_data_t *const out, void const *const data, size_t const length) {
+    if (length < sizeof(struct block_wire) + EMMY_FITNESS_SIZE) return false;
+    struct block_wire const *const block = data;
+    out->type = BAKING_TYPE_BLOCK;
+    out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->chain_id);
+    out->level = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->level);
+
+    void const *const fitness = data + sizeof(struct block_wire);
+    uint8_t proto_version = get_proto_version(fitness);
+    switch (proto_version) {
+        case 0:  // Emmy 0 to 4
+        case 1:  // Emmy 5 to 11
+            out->is_tenderbake = false;
+            out->round = 0;  // irrelevant
+            return true;
+        case 2:  // Tenderbake
+            out->is_tenderbake = true;
+            uint32_t fitness_size = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->fitness_size);
+            out->round = get_round(fitness, fitness_size);
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool parse_consensus_operation(parsed_baking_data_t *const out,
+                               void const *const data,
+                               size_t const length) {
+    if (length < sizeof(struct consensus_op_wire)) return false;
+    struct consensus_op_wire const *const op = data;
+
+    out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->chain_id);
+    out->level = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->level);
+
+    switch (op->tag) {
+        case 0:  // emmy endorsement (without slot)
+            out->type = BAKING_TYPE_ENDORSEMENT;
+            out->is_tenderbake = false;
+            out->round = 0;  // irrelevant
+            return true;
+        case 20:  // tenderbake preendorsement
+        case 21:  // tenderbake endorsement
+            if (length < sizeof(struct tenderbake_consensus_op_wire)) return false;
+            struct tenderbake_consensus_op_wire const *const op = data;
+            out->is_tenderbake = true;
+            out->level = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->level);
+            out->round = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->round);
+            if (op->tag == 20) {
+                out->type = BAKING_TYPE_PREENDORSEMENT;
+            } else {
+                out->type = BAKING_TYPE_ENDORSEMENT;
+            }
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool parse_baking_data(parsed_baking_data_t *const out,
+                       void const *const data,
+                       size_t const length) {
     switch (get_magic_byte(data, length)) {
         case MAGIC_BYTE_BAKING_OP:
-            if (length != sizeof(struct tenderbake_consensus_op_wire)) return false;
-            struct tenderbake_consensus_op_wire const *const operation = data;
-            switch (operation->tag) {
-                case 20:
-                    out->type = BAKING_TYPE_PREENDORSEMENT;
-                    break;
-                case 21:
-                    out->type = BAKING_TYPE_ENDORSEMENT;
-                    break;
-                default:
-                    return false;
-            }
-            out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &operation->chain_id);
-            out->level = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &operation->level);
-            out->round = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &operation->round);
-            return true;
+            return parse_consensus_operation(out, data, length);
         case MAGIC_BYTE_BLOCK:
-            if (length < sizeof(struct tenderbake_block_wire)) return false;
-            struct tenderbake_block_wire const *const block = data;
-            out->type = BAKING_TYPE_BLOCK;
-            out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->chain_id);
-            out->level = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->level);
-            if (block->locked_round_tag == 0) {
-                out->round = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->no_locked_round.round);
-            } else {
-                out->round = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->locked_round.round);
-            }
-            return true;
+            return parse_block(out, data, length);
         case MAGIC_BYTE_INVALID:
         default:
             return false;

--- a/src/baking_auth.c
+++ b/src/baking_auth.c
@@ -30,8 +30,8 @@ void write_high_water_mark(parsed_baking_data_t const *const in) {
         };
         dest->highest_level = CUSTOM_MAX(in->level, dest->highest_level);
         dest->highest_round = in->round;
-        dest->had_endorsement |= in->type == BAKING_TYPE_ENDORSEMENT;
-        dest->had_preendorsement |= in->type == BAKING_TYPE_PREENDORSEMENT;
+        dest->had_endorsement |= (in->type == BAKING_TYPE_ENDORSEMENT || in->type == BAKING_TYPE_TENDERBAKE_ENDORSEMENT);
+        dest->had_preendorsement |= in->type == BAKING_TYPE_TENDERBAKE_PREENDORSEMENT;
         dest->migrated_to_tenderbake |= in->is_tenderbake;
     });
 }
@@ -65,14 +65,14 @@ static bool is_level_authorized(parsed_baking_data_t const *const baking_info) {
                // the level/round
                (baking_info->level == hwm->highest_level &&
                 baking_info->round == hwm->highest_round &&
-                baking_info->type == BAKING_TYPE_ENDORSEMENT && !hwm->had_endorsement) ||
+                baking_info->type == BAKING_TYPE_TENDERBAKE_ENDORSEMENT && !hwm->had_endorsement) ||
 
                // It is ok to sign a preendorsement if we have not already signed neither an
                // endorsement nor a preendorsement for the level/round
                (baking_info->level == hwm->highest_level &&
                 baking_info->round == hwm->highest_round &&
-                baking_info->type == BAKING_TYPE_PREENDORSEMENT && !hwm->had_endorsement &&
-                !hwm->had_preendorsement);
+                baking_info->type == BAKING_TYPE_TENDERBAKE_PREENDORSEMENT &&
+                !hwm->had_endorsement && !hwm->had_preendorsement);
 
     } else {
         if (hwm->migrated_to_tenderbake) return false;
@@ -150,7 +150,6 @@ uint32_t get_round(void const *const fitness, uint32_t fitness_size) {
 bool parse_block(parsed_baking_data_t *const out, void const *const data, size_t const length) {
     if (length < sizeof(struct block_wire) + EMMY_FITNESS_SIZE) return false;
     struct block_wire const *const block = data;
-    out->type = BAKING_TYPE_BLOCK;
     out->chain_id.v = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->chain_id);
     out->level = READ_UNALIGNED_BIG_ENDIAN(level_t, &block->level);
 
@@ -159,10 +158,12 @@ bool parse_block(parsed_baking_data_t *const out, void const *const data, size_t
     switch (proto_version) {
         case 0:  // Emmy 0 to 4
         case 1:  // Emmy 5 to 11
+            out->type = BAKING_TYPE_BLOCK;
             out->is_tenderbake = false;
             out->round = 0;  // irrelevant
             return true;
         case 2:  // Tenderbake
+            out->type = BAKING_TYPE_TENDERBAKE_BLOCK;
             out->is_tenderbake = true;
             uint32_t fitness_size = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &block->fitness_size);
             out->round = get_round(fitness, fitness_size);
@@ -195,9 +196,9 @@ bool parse_consensus_operation(parsed_baking_data_t *const out,
             out->level = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->level);
             out->round = READ_UNALIGNED_BIG_ENDIAN(uint32_t, &op->round);
             if (op->tag == 20) {
-                out->type = BAKING_TYPE_PREENDORSEMENT;
+                out->type = BAKING_TYPE_TENDERBAKE_PREENDORSEMENT;
             } else {
-                out->type = BAKING_TYPE_ENDORSEMENT;
+                out->type = BAKING_TYPE_TENDERBAKE_ENDORSEMENT;
             }
             return true;
         default:
@@ -210,8 +211,11 @@ bool parse_baking_data(parsed_baking_data_t *const out,
                        size_t const length) {
     switch (get_magic_byte(data, length)) {
         case MAGIC_BYTE_BAKING_OP:
+        case MAGIC_BYTE_TENDERBAKE_PREENDORSEMENT:
+        case MAGIC_BYTE_TENDERBAKE_ENDORSEMENT:
             return parse_consensus_operation(out, data, length);
         case MAGIC_BYTE_BLOCK:
+        case MAGIC_BYTE_TENDERBAKE_BLOCK:
             return parse_block(out, data, length);
         case MAGIC_BYTE_INVALID:
         default:

--- a/src/baking_auth.h
+++ b/src/baking_auth.h
@@ -24,4 +24,8 @@ bool parse_baking_data(parsed_baking_data_t *const out,
                        void const *const data,
                        size_t const length);
 
+bool parse_tenderbake_baking_data(parsed_tenderbake_baking_data_t *const out,
+                                  void const *const data,
+                                  size_t const length);
+
 #endif  // #ifdef BAKING_APP

--- a/src/baking_auth.h
+++ b/src/baking_auth.h
@@ -24,7 +24,7 @@ bool parse_baking_data(parsed_baking_data_t *const out,
                        void const *const data,
                        size_t const length);
 
-bool parse_tenderbake_baking_data(parsed_tenderbake_baking_data_t *const out,
+bool parse_tenderbake_baking_data(parsed_baking_data_t *const out,
                                   void const *const data,
                                   size_t const length);
 

--- a/src/baking_auth.h
+++ b/src/baking_auth.h
@@ -24,8 +24,4 @@ bool parse_baking_data(parsed_baking_data_t *const out,
                        void const *const data,
                        size_t const length);
 
-bool parse_tenderbake_baking_data(parsed_baking_data_t *const out,
-                                  void const *const data,
-                                  size_t const length);
-
 #endif  // #ifdef BAKING_APP

--- a/src/globals.c
+++ b/src/globals.c
@@ -75,17 +75,23 @@ void copy_key(char *out, size_t out_size, void *data) {
 }
 
 void copy_hwm(char *out, size_t out_size, void *data) {
-    level_t *level = (level_t *) data;
+    high_watermark_t *hwm = (high_watermark_t *) data;
     (void) out_size;
 
-    number_to_string(out, *level);
+    if (hwm->migrated_to_tenderbake) {
+        size_t len1 = number_to_string(out, hwm->highest_level);
+        out[len1] = ' ';
+        number_to_string(out + len1 + 1, hwm->highest_round);
+    } else {
+        number_to_string(out, hwm->highest_level);
+    }
 }
 
 void calculate_baking_idle_screens_data(void) {
     push_ui_callback("Tezos Baking", copy_string, VERSION);
     push_ui_callback("Chain", copy_chain, &N_data.main_chain_id);
     push_ui_callback("Public Key Hash", copy_key, &N_data.baking_key);
-    push_ui_callback("High Watermark", copy_hwm, &N_data.hwm.main.highest_level);
+    push_ui_callback("High Watermark", copy_hwm, &N_data.hwm.main);
 }
 
 void update_baking_idle_screens(void) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -8,12 +8,15 @@
 #include "cx.h"
 #include "types.h"
 
-#define MAGIC_BYTE_INVALID    0x00
-#define MAGIC_BYTE_BLOCK      0x01
-#define MAGIC_BYTE_BAKING_OP  0x02
-#define MAGIC_BYTE_UNSAFE_OP  0x03
-#define MAGIC_BYTE_UNSAFE_OP2 0x04
-#define MAGIC_BYTE_UNSAFE_OP3 0x05
+#define MAGIC_BYTE_INVALID                   0x00
+#define MAGIC_BYTE_BLOCK                     0x01
+#define MAGIC_BYTE_BAKING_OP                 0x02
+#define MAGIC_BYTE_UNSAFE_OP                 0x03
+#define MAGIC_BYTE_UNSAFE_OP2                0x04
+#define MAGIC_BYTE_UNSAFE_OP3                0x05
+#define MAGIC_BYTE_TENDERBAKE_BLOCK          0x11
+#define MAGIC_BYTE_TENDERBAKE_PREENDORSEMENT 0x12
+#define MAGIC_BYTE_TENDERBAKE_ENDORSEMENT    0x13
 
 static inline uint8_t get_magic_byte(uint8_t const *const data, size_t const length) {
     return (data == NULL || length == 0) ? MAGIC_BYTE_INVALID : *data;

--- a/src/types.h
+++ b/src/types.h
@@ -38,10 +38,17 @@ typedef enum {
     SIGNATURE_TYPE_ED25519 = 3
 } signature_type_t;
 
+typedef enum {
+    BAKING_TYPE_BLOCK = 0,
+    BAKING_TYPE_ENDORSEMENT = 1,
+    BAKING_TYPE_PREENDORSEMENT = 2
+} baking_type_t;
+
 // Return number of bytes to transmit (tx)
 typedef size_t (*apdu_handler)(uint8_t instruction);
 
 typedef uint32_t level_t;
+typedef uint32_t round_t;
 
 #define CHAIN_ID_BASE58_STRING_SIZE sizeof("NetXdQprcVkpaWU")
 
@@ -168,6 +175,13 @@ typedef struct {
     bool is_endorsement;
     level_t level;
 } parsed_baking_data_t;
+
+typedef struct {
+    chain_id_t chain_id;
+    baking_type_t type;
+    level_t level;
+    round_t round;
+} parsed_tenderbake_baking_data_t;
 
 typedef struct parsed_contract {
     uint8_t originated;  // a lightweight bool

--- a/src/types.h
+++ b/src/types.h
@@ -128,6 +128,7 @@ typedef struct {
     round_t highest_round;
     bool had_endorsement;
     bool had_preendorsement;
+    bool migrated_to_tenderbake;
 } high_watermark_t;
 
 typedef struct {

--- a/src/types.h
+++ b/src/types.h
@@ -41,7 +41,9 @@ typedef enum {
 typedef enum {
     BAKING_TYPE_BLOCK = 0,
     BAKING_TYPE_ENDORSEMENT = 1,
-    BAKING_TYPE_PREENDORSEMENT = 2
+    BAKING_TYPE_TENDERBAKE_BLOCK = 2,
+    BAKING_TYPE_TENDERBAKE_ENDORSEMENT = 3,
+    BAKING_TYPE_TENDERBAKE_PREENDORSEMENT = 4
 } baking_type_t;
 
 // Return number of bytes to transmit (tx)

--- a/src/types.h
+++ b/src/types.h
@@ -125,7 +125,9 @@ static inline bool bip32_path_with_curve_eq(bip32_path_with_curve_t volatile con
 
 typedef struct {
     level_t highest_level;
+    round_t highest_round;
     bool had_endorsement;
+    bool had_preendorsement;
 } high_watermark_t;
 
 typedef struct {
@@ -172,16 +174,11 @@ typedef struct {
 
 typedef struct {
     chain_id_t chain_id;
-    bool is_endorsement;
-    level_t level;
-} parsed_baking_data_t;
-
-typedef struct {
-    chain_id_t chain_id;
     baking_type_t type;
     level_t level;
     round_t round;
-} parsed_tenderbake_baking_data_t;
+    bool is_tenderbake;
+} parsed_baking_data_t;
 
 typedef struct parsed_contract {
     uint8_t originated;  // a lightweight bool

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -26,6 +26,7 @@ void push_ui_callback(char *title, string_generation_callback cb, void *data) {
     fmt->callback_fn = cb;
     fmt->data = data;
     global.dynamic_display.formatter_index++;
+    global.dynamic_display.screen_stack_size++;
 }
 
 void init_screen_stack() {

--- a/src/ui_nano_x.c
+++ b/src/ui_nano_x.c
@@ -149,6 +149,11 @@ void clear_data() {
 // `screen_value` by computing `callback_fn` with the `.data` field as a parameter
 void set_screen_data() {
     struct screen_data *fmt = &G_display.screen_stack[G_display.formatter_index];
+    if (fmt->title == NULL) {
+      // Avoid seg faulting for bad reasons...
+      G_display.formatter_index = 0;
+      fmt = &G_display.screen_stack[0];
+    }
     clear_data();
     copy_string((char *) G_display.screen_title, sizeof(G_display.screen_title), fmt->title);
     fmt->callback_fn(G_display.screen_value, sizeof(G_display.screen_value), fmt->data);


### PR DESCRIPTION
This PR adds support for Tenderbake: Tezos upcoming new consensus algorithm. Without this support, validators won't be able to sign blocks and consensus operations. The changes are retro-compatible with the current consensus algorithm. This PR has been manually tested.

The changes also contains a bug-fix introduced in the latest version where the application would segfault. E.g. when the user would change menus (more than 3 times..) after registering its public key to the server.