### PR TITLE
Missing global initialization when signing for swap

### DIFF
--- a/src/swap/handle_swap_sign_transaction.c
+++ b/src/swap/handle_swap_sign_transaction.c
@@ -27,6 +27,7 @@ bool copy_transaction_parameters(const create_transaction_parameters_t* params) 
 }
 
 void handle_swap_sign_transaction(void) {
+    init_globals();
     called_from_swap = true;
     io_seproxyhal_init();
     USB_power(0);


### PR DESCRIPTION
Because of this, the global state is not correctly initialized when signing during the app-exchange signing flow, causing the application to crash in unpredictable ways.