### PR TITLE
fix: bump the maximum adpu size to sign re-proposal blocks

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -13,7 +13,7 @@ void clear_apdu_globals(void);
 // Zeros out all application-specific globals and SDK-specific UI/exchange buffers.
 void init_globals(void);
 
-#define MAX_APDU_SIZE 230  // Maximum number of bytes in a single APDU
+#define MAX_APDU_SIZE 235  // Maximum number of bytes in a single APDU
 
 // Our buffer must accommodate any remainder from hashing and the next message at once.
 #define TEZOS_BUFSIZE (BLAKE2B_BLOCKBYTES + MAX_APDU_SIZE)


### PR DESCRIPTION
This PR fixes an issue that prevent corner-case blocks to be signed. These blocks' data contains 5 more bytes than what is previously allowed (= 230) and what was considered the maximum possible data to sign (in `baking-app` mode).