### PR TITLE
Add Pinnacle Bakery

### DIFF
--- a/tools/BakersRegistryCoreUnfilteredData.json
+++ b/tools/BakersRegistryCoreUnfilteredData.json
@@ -498,5 +498,9 @@
   {
     "bakerName": "Eco Tez",
     "bakerAccount": "tz3e7LbZvUtoXhpUD1yb6wuFodZpfYRb9nWJ"
+  },
+  {
+    "bakerName": "Pinnacle Bakery",
+    "bakerAccount": "tz1cSoWttzYi9taqyHfcKS86b5M31SoaTQdg"
   }
 ]


### PR DESCRIPTION
This PR is to add Pinnacle Bakery to `BakersRegistryCoreUnfilteredData.json`.

[Pinnacle Bakery](https://pinnaclebakery.com) is a new public baker located at `tz1cSoWttzYi9taqyHfcKS86b5M31SoaTQdg`.