### PR TITLE
Fix io seproxyhal power off syscall params

### DIFF
--- a/src/boot.c
+++ b/src/boot.c
@@ -72,7 +72,12 @@ __attribute__((section(".boot"))) int main(arg0) {
 
     // Only reached in case of uncaught exception
 #ifdef BAKING_APP
-    io_seproxyhal_power_off(false);  // Should not be allowed dashboard access
+
+    io_seproxyhal_power_off(
+#if defined API_LEVEL && API_LEVEL > 10
+        false
+#endif
+    );  // Should not be allowed dashboard access
 #else
     exit_app();
 #endif

--- a/src/boot.c
+++ b/src/boot.c
@@ -72,7 +72,7 @@ __attribute__((section(".boot"))) int main(arg0) {
 
     // Only reached in case of uncaught exception
 #ifdef BAKING_APP
-    io_seproxyhal_power_off();  // Should not be allowed dashboard access
+    io_seproxyhal_power_off(false);  // Should not be allowed dashboard access
 #else
     exit_app();
 #endif


### PR DESCRIPTION
Commits taken from #61  and #62 