### PR TITLE
BC2A-1408: Fix conflict name issue during APP building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,4 +199,4 @@ endif
 # Generate delegates from baker list
 src/delegates.h: tools/gen-delegates.sh tools/BakersRegistryCoreUnfilteredData.json
 	bash ./tools/gen-delegates.sh ./tools/BakersRegistryCoreUnfilteredData.json
-$(DEP_DIR)/to_string.d $(DEP_DIR)/app/to_string.d: src/delegates.h
+$(DEP_DIR)/to_string.d $(DEP_DIR)/app/src/to_string.d: src/delegates.h


### PR DESCRIPTION
2nd round of the fix.
After fixing the BC2A-1408 (https://github.com/LedgerHQ/ledger-secure-sdk/pull/445), there is a side effect in this app, because of hardcoded `dep/` directory path.
This PR fixes that to align with sdk update.

**Note**: The `scan-build` fails because of `DEPRECATED` crypto functions

